### PR TITLE
using cloud iot v1

### DIFF
--- a/DataSimulator/create_device.py
+++ b/DataSimulator/create_device.py
@@ -7,7 +7,7 @@ from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
 API_SCOPES = ['https://www.googleapis.com/auth/cloud-platform']
-API_VERSION = 'v1beta1'
+API_VERSION = 'v1'
 DISCOVERY_API = 'https://cloudiot.googleapis.com/$discovery/rest'
 SERVICE_NAME = 'cloudiot'
 


### PR DESCRIPTION
the v1beta1 version is deprecated and does not work anymore https://cloud.google.com/iot/docs/reference/cloudiotdevice/rest/#rest-resource-v1beta1projectslocationsregistriesdevices-deprecated